### PR TITLE
Update read_population.R

### DIFF
--- a/R/read_population.R
+++ b/R/read_population.R
@@ -33,17 +33,19 @@
 read_population <- function( path, type, locus.columns, phased=FALSE, sep=",", header=TRUE, delim=":",...) {
   type <- tolower(type)
   
-  if( !file.exists(path) ){
-    ans <- paste("You did not pass a valid path to this function.  What you passed", 
-                 path, 
-                 "is not the FILE that has data in it, it does not exist." )
-    stop(ans)    
-  }
+  if (!("textConnection" %in% class(file))
+      {
+        if( !file.exists(path) ){
+        ans <- paste("You did not pass a valid path to this function.  What you passed", 
+                       path, 
+                     "is not the FILE that has data in it, it does not exist." )
+        stop(ans)    
+      }
   
   if( file.info(path)$isdir ){
     stop("You passed a directory path, not a file path to read_population().  Pass a path to the actual FILE.")
   }
-  
+}  
   if( !missing(type) && !(type %in% c("aflp","column","separated","snp","zyme","genepop","cdpop","haploid","structure")))
     stop("Unrecognized 'type' submitted to read_population().  Please specify which type of data file you are trying to load in.")
   


### PR DESCRIPTION
Hi Rodney,

we are looking at using gstudio and popgraph in a large number of simulations running on a parallel machine.  We were writing files to disk and rereading using read_population.  To avoid file name collisions for simultaneous jobs, we were looking into using textConnections to provide input for read_population.

Unfortunately the first thing read_population does is check for file and directory existence.  I changed the source to check for textconnections first and then if it is not a textConnection, perform the file.exist tests that you already implemented.

This pull request has the new changes to read_population.R

