### PR TITLE
Changes to better implement textConnections

### DIFF
--- a/man/read_population.Rd
+++ b/man/read_population.Rd
@@ -4,19 +4,11 @@
 \alias{read_population}
 \title{Read a raw text file in and translate appropriate columns into genotypes}
 \usage{
-read_population(
-  path,
-  type,
-  locus.columns,
-  phased = FALSE,
-  sep = ",",
-  header = TRUE,
-  delim = ":",
-  ...
-)
+read_population(path, type, locus.columns, phased = FALSE, sep = ",",
+  header = TRUE, delim = ":", ...)
 }
 \arguments{
-\item{path}{The path to the text file}
+\item{path}{The path to the text file OR a textConnection object that contains genotypes}
 
 \item{type}{An indication of what kind of loci that the data represent. The 
  following kinds are recoginzed (n.b., if you have several types load them
@@ -55,6 +47,16 @@ A \code{data.frame} with \code{locus} columns pre-formatted.
 \description{
 The function reads in a text file and does the proper translations for 
  genotypes and spatial coordinates.
+}
+\examples{
+#Use a text connection rather than file on disk
+#create 0,1,2 snp copy data frame, convert to vector, and use vector as input
+df <- as.data.frame(matrix(round(runif(50,min=0,max=2)),5,10))
+print(df)
+vec <- sapply(1:nrow(df),function(l){paste0(paste(df[l,],collapse=", "),"\\n")})
+print(vec)
+pops <- read_population(path=textConnection(vec),type="snp",sep=",",header=F,locus.columns=1:5)
+print(pops)
 }
 \author{
 Rodney J. Dyer \email{rjdyer@vcu.edu}

--- a/tests/testthat/test-read_population.R
+++ b/tests/testthat/test-read_population.R
@@ -7,7 +7,10 @@ test_that("error checking", {
   # bad locus.columns
   expect_that( (data <- read.population(path, locus.columns="BOB")), throws_error() )
   # wrong value for locus.columns
-  expect_that( (data <- read.population(path, locus.columns=2:40)), throws_error() )  
+  expect_that( (data <- read.population(path, locus.columns=2:40)), throws_error() )
+  # non-file, non text connection
+  path=c(1,2,3)
+  expect_that( (data <- read.population(path, locus.columns=2:40)), throws_error() )
 })
 
 
@@ -50,7 +53,6 @@ test_that("reading snp data file",{
   expect_that( length( column_class(data,"locus")), equals(4) )
 })
 
-
 test_that("reading zyme data file",{
   path <- system.file("extdata","data_zymelike.csv",package="gstudio")
 
@@ -67,6 +69,15 @@ test_that("reading structure data file", {
   expect_that( data, is_a("data.frame") )
   expect_that( length(column_class(data,"locus")), equals(15) )
   
+})
+
+
+test_that("reading snp data from textConnection",{
+    df <- read.csv(system.file("extdata","data_snp.csv",package="gstudio"))
+    vec <- c(paste0(paste(names(df),collapse=","),"\n"),sapply(1:nrow(df),function(l){paste0(paste(df[l,],collapse=", "),"\n")}))
+    data <- read_population(path=textConnection(vec),type="snp",locus.columns=4:7,na.strings=c("NA"))
+    expect_that( data, is_a("data.frame") )
+    expect_that( length( column_class(data,"locus")), equals(4) )
 })
 
 


### PR DESCRIPTION
I have added two tests associated with textConnections.  I also constructed an "example section" 
 for read_populations to show how textConnections could be used.

While constructing them, I noticed that missing data in a text connection caused an issue associated with data frame column types (converted int to chr).  .read_columns() was changed to convert these columns back to int if a textConnection is involved and if they are not already integer

In the end three files have been changed: read_population.R, read_population.Rd (created by running devtools::document()), and test-read_population.R